### PR TITLE
Migrate to Zig 0.16.0 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .zig-cache/
-zig-out/
+zig-out/*
 release-bins/

--- a/src/cli-flags.zig
+++ b/src/cli-flags.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 /// Command line flags parser / helper
 pub const CliFlags = struct {
-    args: []const [:0]u8,
+    args: []const [:0]const u8,
     allocator: std.mem.Allocator,
 
     const Self = @This();
@@ -18,7 +18,7 @@ pub const CliFlags = struct {
 
     /// Free the memory allocated for arguments
     pub fn deinit(self: *const Self) void {
-        self.allocator.free(self.args);   // toSlice allocates, so just free
+        self.allocator.free(self.args); // toSlice allocates, so just free
     }
 
     // ────────────────────────────────────────────────
@@ -26,13 +26,13 @@ pub const CliFlags = struct {
     // ────────────────────────────────────────────────
 
     /// Returns only the arguments (excludes program name = args[0])
-    pub fn getArgs(self: *const Self) []const [:0]u8 {
+    pub fn getArgs(self: *const Self) []const [:0]const u8 {
         if (self.args.len == 0) return &[_][:0]u8{};
         return self.args[1..];
     }
 
     /// Returns all arguments including program name
-    pub fn rawArgs(self: *const Self) []const [:0]u8 {
+    pub fn rawArgs(self: *const Self) []const [:0]const u8 {
         return self.args;
     }
 

--- a/src/cli-flags.zig
+++ b/src/cli-flags.zig
@@ -2,17 +2,14 @@ const std = @import("std");
 
 /// Command line flags parser / helper
 pub const CliFlags = struct {
-    // Using mutable child typehere  to match argsFree() expectation
     args: []const [:0]u8,
     allocator: std.mem.Allocator,
 
     const Self = @This();
 
-    /// Initialize the CliFlags struct with the provided allocator
-    pub fn init(allocator: std.mem.Allocator) !Self {
-        const all_args = try std.process.argsAlloc(allocator);
-        errdefer std.process.argsFree(allocator, all_args);
-
+    /// Initialize using the juicy main `init` (recommended)
+    pub fn init(allocator: std.mem.Allocator, initt: std.process.Init) !Self {
+        const all_args = try initt.minimal.args.toSlice(allocator);
         return Self{
             .args = all_args,
             .allocator = allocator,
@@ -21,7 +18,7 @@ pub const CliFlags = struct {
 
     /// Free the memory allocated for arguments
     pub fn deinit(self: *const Self) void {
-        std.process.argsFree(self.allocator, self.args);
+        self.allocator.free(self.args);   // toSlice allocates, so just free
     }
 
     // ────────────────────────────────────────────────
@@ -39,17 +36,14 @@ pub const CliFlags = struct {
         return self.args;
     }
 
-    /// Number of **user** arguments (excludes program name)
     pub fn len(self: *const Self) usize {
         return if (self.args.len > 0) self.args.len - 1 else 0;
     }
 
-    /// Total number of arguments including argv[0]
     pub fn rawLen(self: *const Self) usize {
         return self.args.len;
     }
 
-    /// Checks if the version flag is enabled
     pub fn isVersionFlagEnabled(self: *const Self) bool {
         for (self.getArgs()) |arg| {
             if (std.mem.eql(u8, arg, "-v") or std.mem.eql(u8, arg, "--version")) {
@@ -59,7 +53,6 @@ pub const CliFlags = struct {
         return false;
     }
 
-    /// Checks if the help flag is enabled
     pub fn isHelpFlagEnabled(self: *const Self) bool {
         for (self.getArgs()) |arg| {
             if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
@@ -69,7 +62,6 @@ pub const CliFlags = struct {
         return false;
     }
 
-    /// Checks if the force flag is enabled
     pub fn isForceFlagEnabled(self: *const Self) bool {
         for (self.getArgs()) |arg| {
             if (std.mem.eql(u8, arg, "-f") or std.mem.eql(u8, arg, "--force")) {
@@ -79,7 +71,6 @@ pub const CliFlags = struct {
         return false;
     }
 
-    /// Checks if the no-backup flag is enabled
     pub fn isNoBackupFlagEnabled(self: *const Self) bool {
         for (self.getArgs()) |arg| {
             if (std.mem.eql(u8, arg, "--no-backup")) {
@@ -89,26 +80,12 @@ pub const CliFlags = struct {
         return false;
     }
 
-    /// Get the custom output name if -o flag is provided
-    /// Returns null if no -o flag is found
     pub fn getOutputName(self: *const Self) ?[:0]const u8 {
         const args_slice = self.getArgs();
         var i: usize = 0;
         while (i < args_slice.len) : (i += 1) {
             const arg = args_slice[i];
-
-            // Check for -o flag
-            if (std.mem.eql(u8, arg, "-o")) {
-                // Next argument should be the output name
-                if (i + 1 < args_slice.len) {
-                    return args_slice[i + 1];
-                }
-                // -o provided but no value - could handle error here
-                return null;
-            }
-
-            // Check for --output flag (optional long form)
-            if (std.mem.eql(u8, arg, "--output")) {
+            if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
                 if (i + 1 < args_slice.len) {
                     return args_slice[i + 1];
                 }
@@ -119,13 +96,10 @@ pub const CliFlags = struct {
     }
 
     /// Get non-flag arguments (source path)
-    /// Filters out flags and their values
     pub fn getPositionalArgs(self: *const Self, allocator: std.mem.Allocator) ![]const [:0]u8 {
-        // Count non-flag args first
-        var count: usize = 0;
         const args_slice = self.getArgs();
+        var count: usize = 0;
         var i: usize = 0;
-
         while (i < args_slice.len) : (i += 1) {
             const arg = args_slice[i];
             if (std.mem.startsWith(u8, arg, "-")) {
@@ -137,11 +111,9 @@ pub const CliFlags = struct {
             count += 1;
         }
 
-        // Allocate and fill
         var positional = try allocator.alloc([:0]u8, count);
         var pos_idx: usize = 0;
         i = 0;
-
         while (i < args_slice.len) : (i += 1) {
             const arg = args_slice[i];
             if (std.mem.startsWith(u8, arg, "-")) {
@@ -153,7 +125,6 @@ pub const CliFlags = struct {
             positional[pos_idx] = @constCast(arg);
             pos_idx += 1;
         }
-
         return positional;
     }
 };

--- a/src/console.zig
+++ b/src/console.zig
@@ -1,125 +1,99 @@
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-///A struct that allows console reading and writing without boilerplate.
-///usage:
+/// A struct that allows console reading and writing without boilerplate.
 /// 
-/// var console:Console = undefined;
-/// console.init(&write_buffer, &read_buffer);
+/// Usage:
+/// ```
+/// var console: Console = undefined;
+/// console.init(init.io, &write_buffer, &read_buffer);
 /// 
 /// Use console.writer or console.reader for all methods.
+/// ```
 pub const Console = struct {
-    out_f:std.fs.File,
-    fw:std.fs.File.Writer,
-    writer:*std.Io.Writer,
-
-    in_file:std.fs.File,
-    fr:std.fs.File.Reader,
-    reader:*std.Io.Reader,
+    io: std.Io,                    // Required in 0.16+
+    out_f: std.Io.File,
+    fw: std.Io.File.Writer,        // Concrete writer (holds buffer + state)
+    writer: *std.Io.Writer,        // Interface
+    in_file: std.Io.File,
+    fr: std.Io.File.Reader,        // Concrete reader
+    reader: *std.Io.Reader,        // Interface
 
     const Self = @This();
 
-    pub fn init(self:*Self, write_buffer:[]u8, read_buffer:[]u8) void {
-        self.out_f = std.fs.File.stdout();
-        self.fw = self.out_f.writer(write_buffer);
+    /// Initialize with an Io instance (e.g. from `init.io` in juicy main)
+    pub fn init(self: *Self, io: std.Io, write_buffer: []u8, read_buffer: []u8) void {
+        self.io = io;
+
+        self.out_f = std.Io.File.stdout();
+        self.fw = self.out_f.writer(io, write_buffer);   // Note: passes io + buffer
         self.writer = &self.fw.interface;
 
-        self.in_file = std.fs.File.stdin();
-        self.fr = self.in_file.reader(read_buffer);
+        self.in_file = std.Io.File.stdin();
+        self.fr = self.in_file.reader(io, read_buffer);
         self.reader = &self.fr.interface;
     }
 
-    ///Prints to the console immediately.
-    ///Use this when you want to see output now.
-    pub fn printLine(self:*const Self, comptime fmt:[]const u8, args:anytype) !void {
+    /// Prints to the console immediately.
+    pub fn printLine(self: *const Self, comptime fmt: []const u8, args: anytype) !void {
         try self.writer.print(fmt, args);
         try self.writer.print("\n", .{});
-        try self.writer.flush();
-    }
-    ///Prints to the console immediately.
-    ///Use this when you want to see output now.
-    pub fn print(self:*const Self, comptime fmt:[]const u8, args:anytype) !void {
-        try self.writer.print(fmt, args);
-        try self.writer.flush();
-    }
-    ///Prints to the console immediately.
-    ///Use this when you want to see output now.
-    pub fn printANewLine(self:*const Self) !void {
-        try self.writer.print("\n", .{});
-        try self.writer.flush();
-    }
-    ///Writes to buffer only, use flush to see it in the console.
-    ///Use this when you want to add many things to the buffer and print them all at once with flush.
-    pub fn writeLine(self:*const Self, comptime fmt:[]const u8, args:anytype) !void {
-        try self.writer.print(fmt, args);
-        try self.writer.print("\n", .{});
-    }
-    ///Writes to buffer only, use flush to see it in the console.
-    ///Use this when you want to add many things to the buffer and print them all at once with flush.
-    pub fn write(self:*const Self, comptime fmt:[]const u8, args:anytype) !void {
-        try self.writer.print(fmt, args);
-    }
-    ///Prints to the console immediately.
-    ///Use this when you want to see output now.
-    pub fn writeANewLine(self:*const Self) !void {
-        try self.writer.print("\n", .{});
-    }
-    ///Prints the buffer to the console
-    pub fn flush(self:*const Self) !void {
         try self.writer.flush();
     }
 
-    /// Reads until a new line character.
-    /// Removes '\r'
-    pub fn readLine(self:*const Self) ![]u8 {
-        var line:[]u8 = try self.reader.takeDelimiterExclusive('\n');
+    /// Prints to the console immediately.
+    pub fn print(self: *const Self, comptime fmt: []const u8, args: anytype) !void {
+        try self.writer.print(fmt, args);
+        try self.writer.flush();
+    }
 
-        // Handle optional CR before LF (Windows-style)
+    pub fn printANewLine(self: *const Self) !void {
+        try self.writer.print("\n", .{});
+        try self.writer.flush();
+    }
+
+    /// Writes to buffer only (flush later).
+    pub fn writeLine(self: *const Self, comptime fmt: []const u8, args: anytype) !void {
+        try self.writer.print(fmt, args);
+        try self.writer.print("\n", .{});
+    }
+
+    pub fn write(self: *const Self, comptime fmt: []const u8, args: anytype) !void {
+        try self.writer.print(fmt, args);
+    }
+
+    pub fn writeANewLine(self: *const Self) !void {
+        try self.writer.print("\n", .{});
+    }
+
+    pub fn flush(self: *const Self) !void {
+        try self.writer.flush();
+    }
+
+    /// Reads until a new line character. Removes trailing '\r' (Windows).
+    pub fn readLine(self: *const Self) ![]u8 {
+        var line: []u8 = try self.reader.takeDelimiterExclusive('\n');
+        // Handle optional CR before LF
         if (line.len > 0 and line[line.len - 1] == '\r') {
             line = line[0 .. line.len - 1];
         }
-
         return line;
     }
 
-    /// Fills the buffer such that it contains at least `n` bytes, without
-    /// advancing the seek position.
-    ///
-    /// Returns `error.EndOfStream` if and only if there are fewer than `n` bytes
-    /// remaining.
-    ///
-    /// If the end of stream is not encountered, asserts buffer capacity is at
-    /// least `n`.
-    pub fn fill(self:*const Self, n:usize) !void {
+    // The rest of the methods (fill, peek, peekByte, readByte) stay almost identical
+    pub fn fill(self: *const Self, n: usize) !void {
         try self.reader.fill(n);
     }
 
-    /// Returns the next `len` bytes from the stream, filling the buffer as
-    /// necessary.
-    ///
-    /// Invalidates previously returned values from `peek`.
-    ///
-    /// Asserts that the `Reader` was initialized with a buffer capacity at
-    /// least as big as `len`.
-    ///
-    /// If there are fewer than `len` bytes left in the stream, `error.EndOfStream`
-    /// is returned instead.
-    pub fn peek(self:*const Self, n:usize) ![]u8 {
+    pub fn peek(self: *const Self, n: usize) ![]u8 {
         return try self.reader.peek(n);
     }
-    /// Returns the next byte from the stream or returns `error.EndOfStream`.
-    ///
-    /// Does not advance the seek position.
-    ///
-    /// Asserts the buffer capacity is nonzero.
-    pub fn peekByte(self:*const Self) !u8 {
+
+    pub fn peekByte(self: *const Self) !u8 {
         return try self.reader.peekByte();
     }
-    /// Reads 1 byte from the stream or returns `error.EndOfStream`.
-    ///
-    /// Asserts the buffer capacity is nonzero.
-    pub fn readByte(self:*const Self) !u8 {
+
+    pub fn readByte(self: *const Self) !u8 {
         return try self.reader.takeByte();
     }
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -93,10 +93,10 @@ pub fn main(init: std.process.Init) !void {
     try utils.copyToDestination(io, src_path, dest_path);
 
     // Make executable (macOS/Linux)
-    if (comptime std.fs.has_executable_bit) {
-        const file = try std.Io.File.open(dest_path, .{ .mode = .read_write });
-        defer file.close(io); // close now takes io
-        try file.chmod(io, 0o755);
+    if (comptime std.Io.File.Permissions.has_executable_bit) {
+        const file = try std.Io.Dir.cwd().openFile(io, dest_path, .{ .mode = .read_write });
+        defer file.close(io);
+        try file.setPermissions(io, @as(std.Io.File.Permissions, @enumFromInt(0o755)));
     }
 
     try console.printLine("Successfully installed: {s}", .{dest_path});

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,7 @@ const string: type = []const u8;
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
-    const cli = try CliFlags.init(allocator);
+    const cli = try CliFlags.init(allocator,init);
     defer cli.deinit();
 
     var write_buffer: [1024]u8 = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,7 +45,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     const src_path = positional_args[0];
-    if (!try utils.fileExists(src_path)) {
+    if (!try utils.fileExists(init.io,src_path)) {
         try console.printLine("Source file not found: {s}", .{src_path});
         return;
     }
@@ -75,6 +75,7 @@ pub fn main(init: std.process.Init) !void {
             try console.printLine("Creating backup...", .{});
             backed_up_path = try utils.backupAndRemoveExistingBin(
                 allocator,
+                init.io,
                 dest_path,
                 null, // custom backup dir if needed
             );
@@ -83,15 +84,15 @@ pub fn main(init: std.process.Init) !void {
             }
         } else {
             try console.printLine("Removing existing file (no backup requested)...", .{});
-            try utils.deleteExistingBin(dest_path);
+            try utils.deleteExistingBin(init.io, dest_path);
         }
     }
 
-    try utils.copyToDestination(src_path, dest_path);
+    try utils.copyToDestination(init.io, src_path, dest_path);
 
     // Make executable (macOS/Linux)
     if (comptime std.fs.has_executable_bit) {
-        const file = try std.Io.File.open(dest_path, .{ .mode = .read_write }); // adjust if your utils use old API
+        const file = try std.Io.File.open(dest_path, .{ .mode = .read_write });
         defer file.close(init.io);  // close now takes io
         try file.chmod(init.io, 0o755);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,14 +8,16 @@ const string: type = []const u8;
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
-    const cli = try CliFlags.init(allocator,init);
+    const io = io;
+
+    const cli = try CliFlags.init(allocator, init);
     defer cli.deinit();
 
     var write_buffer: [1024]u8 = undefined;
     var read_buffer: [1024]u8 = undefined;
 
     var console: Console = undefined;
-    console.init(init.io, &write_buffer, &read_buffer);
+    console.init(io, &write_buffer, &read_buffer);
 
     if (cli.getArgs().len == 0) {
         try console.printLine(utils.HelpText(), .{});
@@ -45,7 +47,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     const src_path = positional_args[0];
-    if (!try utils.fileExists(init.io,src_path)) {
+    if (!try utils.fileExists(io, src_path)) {
         try console.printLine("Source file not found: {s}", .{src_path});
         return;
     }
@@ -71,11 +73,11 @@ pub fn main(init: std.process.Init) !void {
             }
         }
 
-        if (utils.shouldCreateBackup(force, no_backup)) {
+        if (utils.shouldCreateBackup(no_backup)) {
             try console.printLine("Creating backup...", .{});
             backed_up_path = try utils.backupAndRemoveExistingBin(
                 allocator,
-                init.io,
+                io,
                 dest_path,
                 null, // custom backup dir if needed
             );
@@ -84,17 +86,17 @@ pub fn main(init: std.process.Init) !void {
             }
         } else {
             try console.printLine("Removing existing file (no backup requested)...", .{});
-            try utils.deleteExistingBin(init.io, dest_path);
+            try utils.deleteExistingBin(io, dest_path);
         }
     }
 
-    try utils.copyToDestination(init.io, src_path, dest_path);
+    try utils.copyToDestination(io, src_path, dest_path);
 
     // Make executable (macOS/Linux)
     if (comptime std.fs.has_executable_bit) {
         const file = try std.Io.File.open(dest_path, .{ .mode = .read_write });
-        defer file.close(init.io);  // close now takes io
-        try file.chmod(init.io, 0o755);
+        defer file.close(io); // close now takes io
+        try file.chmod(io, 0o755);
     }
 
     try console.printLine("Successfully installed: {s}", .{dest_path});

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,7 @@ const CliFlags = @import("cli-flags.zig").CliFlags;
 const heap = std.heap;
 const string: type = []const u8;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
     defer _ = gpa.deinit();
@@ -19,7 +19,7 @@ pub fn main() !void {
     var write_buffer: [1024]u8 = undefined;
     var read_buffer: [1024]u8 = undefined;
     var console: Console = undefined;
-    console.init(&write_buffer, &read_buffer);
+    console.init(init.io, &write_buffer, &read_buffer);
 
     if (cli.getArgs().len == 0) { // i check if there are no arguments
         try console.printLine(utils.HelpText(), .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,34 +1,30 @@
 const std = @import("std");
-const fs = std.fs;
 const utils = @import("utils.zig");
 const Console = @import("console.zig").Console;
 const constants = @import("constants.zig");
 const CliFlags = @import("cli-flags.zig").CliFlags;
 
-const heap = std.heap;
 const string: type = []const u8;
 
 pub fn main(init: std.process.Init) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-    defer _ = gpa.deinit();
-
+    const allocator = init.gpa;
     const cli = try CliFlags.init(allocator);
     defer cli.deinit();
 
     var write_buffer: [1024]u8 = undefined;
     var read_buffer: [1024]u8 = undefined;
+
     var console: Console = undefined;
     console.init(init.io, &write_buffer, &read_buffer);
 
-    if (cli.getArgs().len == 0) { // i check if there are no arguments
+    if (cli.getArgs().len == 0) {
         try console.printLine(utils.HelpText(), .{});
         return;
     }
 
     const version_enabled = cli.isVersionFlagEnabled();
     if (version_enabled) {
-        try console.printLine("movebin version {s}\n", .{constants.VERSION});
+        try console.printLine("movebin version {s}", .{constants.VERSION});
         return;
     }
 
@@ -38,28 +34,24 @@ pub fn main(init: std.process.Init) !void {
         return;
     }
 
-    // Getting the positional arguments (non-flags)
+    // Getting the positional arguments
     const positional_args = try cli.getPositionalArgs(allocator);
     defer allocator.free(positional_args);
 
     if (positional_args.len == 0) {
-        try console.printLine("Error: No source file specified\n", .{});
+        try console.printLine("Error: No source file specified", .{});
         try console.printLine(utils.HelpText(), .{});
         return;
     }
 
     const src_path = positional_args[0];
     if (!try utils.fileExists(src_path)) {
-        try console.printLine("Source file not found: {s}\n", .{src_path});
+        try console.printLine("Source file not found: {s}", .{src_path});
         return;
     }
 
     // Determine destination filename
-    const dest_filename = if (cli.getOutputName()) |custom_name|
-        custom_name
-    else
-        std.fs.path.basename(src_path);
-
+    const dest_filename = cli.getOutputName() orelse std.fs.path.basename(src_path);
     const dest_path = try std.fs.path.join(allocator, &.{ "/usr/local/bin", dest_filename });
     defer allocator.free(dest_path);
 
@@ -70,40 +62,39 @@ pub fn main(init: std.process.Init) !void {
     defer if (backed_up_path) |p| allocator.free(p);
 
     const dest_exists = try utils.fileExists(dest_path);
-
     if (dest_exists) {
         if (!force) {
             const confirmed = try utils.askYesNo(console, "Destination already exists. Overwrite?", false);
             if (!confirmed) {
-                try console.printLine("Aborted.\n", .{});
+                try console.printLine("Aborted.", .{});
                 return;
             }
         }
 
-        // Decide whether to backup
         if (utils.shouldCreateBackup(force, no_backup)) {
-            try console.printLine("Creating backup...\n", .{});
+            try console.printLine("Creating backup...", .{});
             backed_up_path = try utils.backupAndRemoveExistingBin(
                 allocator,
                 dest_path,
-                null, // or i will pass custom backup dir
+                null, // custom backup dir if needed
             );
             if (backed_up_path) |bp| {
-                try console.printLine("Backup created: {s}\n", .{bp});
+                try console.printLine("Backup created: {s}", .{bp});
             }
         } else {
-            try console.printLine("Removing existing file (no backup requested)...\n", .{});
+            try console.printLine("Removing existing file (no backup requested)...", .{});
             try utils.deleteExistingBin(dest_path);
         }
     }
 
     try utils.copyToDestination(src_path, dest_path);
 
-    if (comptime fs.has_executable_bit) {
-        const file = try fs.cwd().openFile(dest_path, .{ .mode = .read_write });
-        defer file.close();
-        try file.chmod(0o755);
+    // Make executable (macOS/Linux)
+    if (comptime std.fs.has_executable_bit) {
+        const file = try std.Io.File.open(dest_path, .{ .mode = .read_write }); // adjust if your utils use old API
+        defer file.close(init.io);  // close now takes io
+        try file.chmod(init.io, 0o755);
     }
 
-    try console.printLine("Successfully installed: {s}\n", .{dest_path});
+    try console.printLine("Successfully installed: {s}", .{dest_path});
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,7 @@ const string: type = []const u8;
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
-    const io = io;
+    const io = init.io;
 
     const cli = try CliFlags.init(allocator, init);
     defer cli.deinit();
@@ -63,7 +63,7 @@ pub fn main(init: std.process.Init) !void {
     var backed_up_path: ?[]u8 = null;
     defer if (backed_up_path) |p| allocator.free(p);
 
-    const dest_exists = try utils.fileExists(dest_path);
+    const dest_exists = try utils.fileExists(io, dest_path);
     if (dest_exists) {
         if (!force) {
             const confirmed = try utils.askYesNo(console, "Destination already exists. Overwrite?", false);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -88,7 +88,8 @@ pub fn backupAndRemoveExistingBin(
         try std.Io.Dir.cwd().createDir(io, backup_parent, .default_dir);
     }
 
-    const timestamp = std.time.timestamp();
+    const now_ts = std.Io.Clock.Timestamp.now(io, .real);
+    const timestamp = @as(i64, @intCast(@divFloor(now_ts.raw.nanoseconds, std.time.ns_per_s)));
     const backup_name = try std.fmt.allocPrint(
         allocator,
         "{s}_{d}",
@@ -99,7 +100,7 @@ pub fn backupAndRemoveExistingBin(
     const backup_path = try std.fs.path.join(allocator, &.{ backup_parent, backup_name });
 
     // Copy then delete original
-    try std.Io.Dir.cwd().copyFile(io, dest_path, std.Io.Dir.cwd(), backup_path, .{});
+    try std.Io.Dir.cwd().copyFile(dest_path, std.Io.Dir.cwd(), backup_path, io, .{});
     try std.Io.Dir.cwd().deleteFile(io, dest_path);
 
     return backup_path;
@@ -107,7 +108,7 @@ pub fn backupAndRemoveExistingBin(
 
 /// Copy the binary to the destination path
 pub fn copyToDestination(io: std.Io, src_path: []const u8, dest_path: []const u8) !void {
-    try std.Io.Dir.cwd().copyFile(io, src_path, std.Io.Dir.cwd(), dest_path, .{});
+    try std.Io.Dir.cwd().copyFile(src_path, std.Io.Dir.cwd(), dest_path, io, .{});
 }
 
 /// Delete the existing binary at the destination path.

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -3,13 +3,12 @@ const fs = std.fs;
 const Console = @import("console.zig").Console;
 
 /// Check if a file exists at the given path.
-pub fn fileExists(path: []const u8) !bool {
-    var found = true;
-    fs.cwd().access(path, .{}) catch |err| switch (err) {
-        error.FileNotFound => found = false,
+pub fn fileExists(io: std.Io, path: []const u8) !bool {
+    std.Io.Dir.cwd().access(io, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
         else => return err,
     };
-    return found;
+    return true;
 }
 
 /// Prompt the user with a yes/no question.

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const fs = std.fs;
 const Console = @import("console.zig").Console;
 
 /// Check if a file exists at the given path.
@@ -19,17 +18,18 @@ pub fn askYesNo(console: Console, prompt: []const u8, default_yes: bool) !bool {
         } else {
             try console.print("{s} [y/N]: ", .{prompt});
         }
-
         const line: []u8 = try console.readLine();
-
+        if (line.len == 0) {
+            return default_yes;
+        }
         const c = std.ascii.toLower(line[0]);
         if (c == 'y') return true;
         if (c == 'n') return false;
-
         try console.print("Invalid input. Please type y or n.\n", .{});
     }
 }
 
+/// Check if the version flag (-v or --version) is present
 pub fn isVersionFlagEnabled(args: []const []const u8) bool {
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "-v") or std.mem.eql(u8, arg, "--version")) {
@@ -39,7 +39,7 @@ pub fn isVersionFlagEnabled(args: []const []const u8) bool {
     return false;
 }
 
-/// Check if the force flag (-f or --force) is present in the arguments.
+/// Check if the force flag (-f or --force) is present
 pub fn isForceFlagEnabled(args: []const []const u8) bool {
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "-f") or std.mem.eql(u8, arg, "--force")) {
@@ -49,7 +49,7 @@ pub fn isForceFlagEnabled(args: []const []const u8) bool {
     return false;
 }
 
-/// Check if the no-backup flag (--no-backup) is present in the arguments.
+/// Check if the no-backup flag (--no-backup) is present
 pub fn isNoBackupFlag(args: []const []const u8) bool {
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--no-backup")) {
@@ -60,35 +60,32 @@ pub fn isNoBackupFlag(args: []const []const u8) bool {
 }
 
 pub fn shouldCreateBackup(force: bool, no_backup: bool) bool {
-    _ = force;
     if (no_backup) return false;
-    return true; // backup by default — even with force
-    // Alternative (more aggressive): return force or !force;
+    return true; // backup by default
 }
 
-/// Backup the existing binary and remove it from the destination path.
-/// `usr/local/bin/somebinary` -> `usr/local/bin/.movebin_backups/somebinary_timestamp`
-/// If backup_dir is null, a default hidden directory next to the destination will be used.
+/// Backup the existing binary and remove it.
+/// Returns the backup path (or null if no backup was made).
 pub fn backupAndRemoveExistingBin(
     allocator: std.mem.Allocator,
+    io: std.Io,
     dest_path: []const u8,
     backup_dir: ?[]const u8,
-) !?[]u8 { // returns backup path or null if no backup was made
-    if (!try fileExists(dest_path)) {
+) !?[]u8 {
+    if (!try fileExists(io, dest_path)) {
         return null;
     }
 
-    const dir = fs.path.dirname(dest_path) orelse ".";
-    const filename = fs.path.basename(dest_path);
+    const dir = std.fs.path.dirname(dest_path) orelse ".";
+    const filename = std.fs.path.basename(dest_path);
 
     const backup_parent = backup_dir orelse
-        try fs.path.join(allocator, &.{ dir, ".movebin_backups" });
-
+        try std.fs.path.join(allocator, &.{ dir, ".movebin_backups" });
     defer if (backup_dir == null) allocator.free(backup_parent);
 
-    // Create backup dir if needed
-    if (!try fileExists(backup_parent)) {
-        try fs.cwd().makeDir(backup_parent);
+    // Create backup directory if it doesn't exist
+    if (!try fileExists(io, backup_parent)) {
+        try std.Io.Dir.cwd().makeDir(io, backup_parent);
     }
 
     const timestamp = std.time.timestamp();
@@ -99,49 +96,41 @@ pub fn backupAndRemoveExistingBin(
     );
     defer allocator.free(backup_name);
 
-    const backup_path = try fs.path.join(
-        allocator,
-        &.{ backup_parent, backup_name },
-    );
+    const backup_path = try std.fs.path.join(allocator, &.{ backup_parent, backup_name });
 
-    try fs.cwd().copyFile(dest_path, fs.cwd(), backup_path, .{});
-
-    try fs.deleteFileAbsolute(dest_path);
+    // Copy then delete original
+    try std.Io.Dir.cwd().copyFile(io, dest_path, std.Io.Dir.cwd(), backup_path, .{});
+    try std.Io.Dir.cwd().deleteFile(io, dest_path);
 
     return backup_path;
 }
 
-///Copy the bin to the destination path
-pub fn copyToDestination(src_path: []const u8, dest_path: []const u8) !void {
-    try fs.cwd().copyFile(src_path, std.fs.cwd(), dest_path, .{});
-    // const dest_file = try fs.cwd().openFile(dest_path, .{ .read = true, .write = true });
-    // defer dest_file.close();
-    // try fs.File.setPermissions(dest_file, .{ .user = .rwx, .group = .rx, .other = .rx });
+/// Copy the binary to the destination path
+pub fn copyToDestination(io: std.Io, src_path: []const u8, dest_path: []const u8) !void {
+    try std.Io.Dir.cwd().copyFile(io, src_path, std.Io.Dir.cwd(), dest_path, .{});
 }
-
-//TODO: Add a function to back up existing binary before deletion
 
 /// Delete the existing binary at the destination path.
-pub fn deleteExistingBin(path: []const u8) !void {
-    try fs.deleteFileAbsolute(path);
+pub fn deleteExistingBin(io: std.Io, path: []const u8) !void {
+    try std.Io.Dir.cwd().deleteFile(io, path);
 }
 
-/// Returns the help text for the movebin command.
+/// Returns the help text
 pub fn HelpText() []const u8 {
-    return 
+    return
     \\Usage: sudo movebin <binary_path> [OPTIONS]
     \\
     \\Options:
-    \\  -o, --output <name>    Set a custom binary name
-    \\  -f, --force            Force overwrite without prompting
-    \\  --no-backup            Skip backup creation
-    \\  -h, --help             Show this help message
-    \\  -v, --version          Show version information
+    \\ -o, --output <name>   Set a custom binary name
+    \\ -f, --force           Force overwrite without prompting
+    \\ --no-backup           Skip backup creation
+    \\ -h, --help            Show this help message
+    \\ -v, --version         Show version information
     \\
     \\Examples:
-    \\  movebin ./my-script                Install as my-script
-    \\  movebin ./my-script -o custom      Install as custom
-    \\  movebin ./my-script -o tool -f     Install as tool, force overwrite
+    \\ movebin ./my-script
+    \\ movebin ./my-script -o custom
+    \\ movebin ./my-script -o tool -f
     \\
     ;
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -85,7 +85,7 @@ pub fn backupAndRemoveExistingBin(
 
     // Create backup directory if it doesn't exist
     if (!try fileExists(io, backup_parent)) {
-        try std.Io.Dir.cwd().makeDir(io, backup_parent);
+        try std.Io.Dir.cwd().createDir(io, backup_parent, .default_dir);
     }
 
     const timestamp = std.time.timestamp();

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -59,7 +59,7 @@ pub fn isNoBackupFlag(args: []const []const u8) bool {
     return false;
 }
 
-pub fn shouldCreateBackup(force: bool, no_backup: bool) bool {
+pub fn shouldCreateBackup(no_backup: bool) bool {
     if (no_backup) return false;
     return true; // backup by default
 }


### PR DESCRIPTION
## Summary

Updates the entire codebase from the pre-0.16 Zig std API to the new `std.Io`-based API introduced in Zig 0.16.0.

## Changes

### Core API migration
- **Main entry point**: Use `std.process.Init` instead of the old `main` signature, with `init.gpa` allocator and `init.io` for I/O
- **Console**: Adapted to use `std.Io` for reading/writing
- **CLI flags**: Migrated to `std.process.Init.Minimal.args.toSlice()` for argument parsing, with proper `[:0]const u8` typing

### File system operations
- `makeDir` → `std.Io.Dir.cwd().createDir()` with explicit permissions
- `chmod` → `file.setPermissions()`
- `has_executable_bit` → `std.Io.File.Permissions.has_executable_bit`
- `copyFile` parameter order updated (`io` moved after paths)
- `File.open` → `Dir.cwd().openFile()`

### Removed/deprecated APIs
- `std.time.timestamp()` → `std.Io.Clock.Timestamp.now(io, .real)`
- Unused `force` parameter removed from `shouldCreateBackup`

### Bug fixes
- Fixed self-referencing typo: `const io = io;` → `const io = init.io;`
- Fixed missing `io` argument in `fileExists` call

## Commits

11 commits total, all on the `upgrade-to-zig0.16.0` branch.